### PR TITLE
Delegate AuthScreen logic to ViewModel

### DIFF
--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
@@ -172,9 +172,16 @@ fun LandingScreen(onStartTapped: () -> Unit) {
 @Composable
 fun AuthScreen(onAuthSuccess: (String) -> Unit, viewModel: AuthViewModel = viewModel()
 ) {
+    val context = LocalContext.current
     var username = viewModel.username
     var password = viewModel.password
     var isLoading = viewModel.isLoading
+
+    LaunchedEffect(true) {
+        viewModel.uiEvents.collect { message -> // Collect messages from ViewModel
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        }
+    }
 
     Box (modifier = Modifier.fillMaxSize()) {
         Image(

--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/AuthViewModel.kt
@@ -6,7 +6,6 @@ import android.widget.Toast
 import androidx.compose.runtime.*
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import at.se2_ss2025_gruppec.carcasonnefrontend.ApiClient
 import at.se2_ss2025_gruppec.carcasonnefrontend.ApiClient.authApi
 import at.se2_ss2025_gruppec.carcasonnefrontend.LoginRequest
 import at.se2_ss2025_gruppec.carcasonnefrontend.RegisterRequest
@@ -29,7 +28,7 @@ class AuthViewModel(app: Application) : AndroidViewModel(app) {
         viewModelScope.launch {
             val request = LoginRequest(username, password)
             try {
-                val response = ApiClient.authApi.login(request) //Store TokenResponse in val response
+                val response = authApi.login(request) //Store TokenResponse in val response
                 TokenManager.userToken = response.token
                 onAuthSuccess(response.token) //Pass actual JWT string to onAuthSuccess
             } catch (e: HttpException) { //Catch HTTP-specific exceptions
@@ -57,8 +56,9 @@ class AuthViewModel(app: Application) : AndroidViewModel(app) {
                 val errorMsg = parseErrorMessage(errorBody)
                 Toast.makeText(context, "Registration failed: $errorMsg", Toast.LENGTH_LONG).show()
             } catch (e: Exception) {
-                isLoading = false
                 Toast.makeText(context, "Registration failed: ${e.message}", Toast.LENGTH_SHORT).show()
+            } finally {
+                isLoading = false
             }
         }
     }

--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/AuthViewModel.kt
@@ -1,0 +1,66 @@
+package at.se2_ss2025_gruppec.carcasonnefrontend.viewmodel
+
+import android.annotation.SuppressLint
+import android.app.Application
+import android.widget.Toast
+import androidx.compose.runtime.*
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import at.se2_ss2025_gruppec.carcasonnefrontend.ApiClient
+import at.se2_ss2025_gruppec.carcasonnefrontend.ApiClient.authApi
+import at.se2_ss2025_gruppec.carcasonnefrontend.LoginRequest
+import at.se2_ss2025_gruppec.carcasonnefrontend.RegisterRequest
+import at.se2_ss2025_gruppec.carcasonnefrontend.TokenManager
+import at.se2_ss2025_gruppec.carcasonnefrontend.parseErrorMessage
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+
+class AuthViewModel(app: Application) : AndroidViewModel(app) {
+    var username by mutableStateOf("")
+    var password by mutableStateOf("")
+    var isLoading by mutableStateOf(false)
+
+    @SuppressLint("StaticFieldLeak")
+    private val context = getApplication<Application>().applicationContext
+
+    fun login(onAuthSuccess: (String) -> Unit) {
+        isLoading = true
+
+        viewModelScope.launch {
+            val request = LoginRequest(username, password)
+            try {
+                val response = ApiClient.authApi.login(request) //Store TokenResponse in val response
+                TokenManager.userToken = response.token
+                onAuthSuccess(response.token) //Pass actual JWT string to onAuthSuccess
+            } catch (e: HttpException) { //Catch HTTP-specific exceptions
+                val errorBody = e.response()?.errorBody()?.string() //Get raw error body from HTTP response
+                val errorMsg = parseErrorMessage(errorBody) //Parse actual message from error body JSON
+                Toast.makeText(context, "Login failed: $errorMsg", Toast.LENGTH_SHORT).show()
+            } catch (e: Exception) { //Catch-all for other exceptions
+                Toast.makeText(context, "Login failed: ${e.message}", Toast.LENGTH_SHORT).show()
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    fun register() {
+        isLoading = true
+
+        viewModelScope.launch {
+            val request = RegisterRequest(username, password)
+            try {
+                authApi.register(request) //Success message easier to handle here, no need to store HTTP 201 from backend
+                Toast.makeText(context, "Registration successful!", Toast.LENGTH_SHORT).show()
+            } catch (e: HttpException) {
+                val errorBody = e.response()?.errorBody()?.string()
+                val errorMsg = parseErrorMessage(errorBody)
+                Toast.makeText(context, "Registration failed: $errorMsg", Toast.LENGTH_LONG).show()
+            } catch (e: Exception) {
+                isLoading = false
+                Toast.makeText(context, "Registration failed: ${e.message}", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
- Created ViewModel for Login/Register functions
- Updated AuthScreen to rely on ViewModel for logic
- Switched to regular ViewModel as per [thesalvenmoser](https://github.com/thesalvenmoser)'s suggestion