### PR TITLE
Enhance and Sync Deck & Score UI Across Clients

### DIFF
--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
@@ -391,6 +391,7 @@ fun AuthScreen(onAuthSuccess: (String) -> Unit, viewModel: AuthViewModel = viewM
                         }
                     }
                 )
+                Spacer(modifier = Modifier.height(100.dp))
             }
         }
     }
@@ -1181,7 +1182,7 @@ fun BottomScreenBar(viewModel: GameViewModel, gameId: String) {
                         modifier = Modifier
                             .size(65.dp)
                             .clickable {
-                                viewModel.setMeeplePlacement(false)
+                                viewModel.skipMeeple(gameId)
                                 viewModel.requestScoreUpdate(gameId) // Punkteberechnung starten
                             }
                     )

--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
@@ -68,10 +68,8 @@ import org.json.JSONObject
 import androidx.compose.ui.unit.IntSize
 import androidx.core.content.ContextCompat
 import at.se2_ss2025_gruppec.carcasonnefrontend.model.Position
-import androidx.core.graphics.drawable.toBitmap
 import at.se2_ss2025_gruppec.carcasonnefrontend.model.Meeple
 import at.se2_ss2025_gruppec.carcasonnefrontend.model.MeeplePosition
-import at.se2_ss2025_gruppec.carcasonnefrontend.model.MeepleType
 import at.se2_ss2025_gruppec.carcasonnefrontend.viewmodel.GameViewModel
 import at.se2_ss2025_gruppec.carcasonnefrontend.model.Tile
 import at.se2_ss2025_gruppec.carcasonnefrontend.model.TileRotation
@@ -105,7 +103,6 @@ class MainActivity : ComponentActivity() {
                         }).apply { connect() }
                     })
                 }
-
 
                 NavHost(navController = navController, startDestination = "landing") {
                     composable("landing") { LandingScreen(onStartTapped = {
@@ -394,14 +391,6 @@ fun AuthScreen(onAuthSuccess: (String) -> Unit, viewModel: AuthViewModel = viewM
                         }
                     }
                 )
-                Spacer(modifier = Modifier.height(16.dp))
-
-                PixelArtButton( //Just for development
-                    label = "Skip (for devs)",
-                    onClick = {
-                        onAuthSuccess("mock-jwt")
-                    }
-                )
             }
         }
     }
@@ -635,7 +624,6 @@ fun LobbyScreen(gameId: String, playerName: String, stompClient: MyClient, navCo
         while (!stompClient.isConnected()) {
             delay(100)
         }
-
         //Subscribe to both public and private channels
         stompClient.listenOn("/topic/game/$gameId") { handleLobbyMessage(it) }
         stompClient.listenOn("/user/queue/private") { handleLobbyMessage(it) }

--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
@@ -796,7 +796,7 @@ fun GameplayScreen(gameId: String, playerName: String, stompClient: MyClient, na
         Column(modifier = Modifier.fillMaxSize()) {
             Spacer(modifier = Modifier.height(40.dp))
 
-            PlayerRow()
+            PlayerRow(viewModel)
 
             Spacer(modifier = Modifier.height(20.dp))
 
@@ -822,7 +822,7 @@ fun GameplayScreen(gameId: String, playerName: String, stompClient: MyClient, na
                         if (viewModel.isValidPlacement(pos)) {
                             viewModel.placeTileAt(pos, gameId)
                         } else {
-                            Log.e("Game", "Invalid tile placement at $pos — no adjacent tiles or already occupied")
+                            Log.e("Frontend Guard", "Invalid tile placement at $pos — no adjacent tiles or already occupied")
                         }
                     },
 
@@ -853,19 +853,6 @@ fun GameplayScreen(gameId: String, playerName: String, stompClient: MyClient, na
                             tileId  = targetTile.id,
                             position= zone.name
                         )
-
-                        /* currentTile?.let { tile ->
-                            val playerId = TokenManager.loggedInUsername ?: "unknown"
-                            //val meepleId = "test_meeple_123"
-
-                            if (zone != null) { // Stelle sicher, dass zone nicht null ist
-                                Log.d("GameplayScreen", "Meeple wird platziert mit gameId=$gameId, playerId=$playerId, tileId=${tile.id}, position=${zone.name}") // Debug-Log für placeMeeple
-                                viewModel.placeMeeple(gameId, playerId, meepleId, tile.id, zone.name)
-                            } else {
-                                Log.e("GameplayScreen", "Ungültige Meeple-Zone erkannt – keine Platzierung!")
-                            }
-                        } ?: Log.e("GameplayScreen", "Kein aktueller Tile vorhanden!") */
-
                     },
                     modifier = Modifier.weight(1f).fillMaxWidth()
                 )
@@ -880,21 +867,37 @@ fun GameplayScreen(gameId: String, playerName: String, stompClient: MyClient, na
 }
 
 @Composable
-fun PlayerRow() {
+fun PlayerRow(viewModel: GameViewModel) {
+    val players = viewModel.players
+    val currentPlayerId by viewModel.currentPlayerId
+
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp),
         horizontalArrangement = Arrangement.SpaceEvenly
     ) {
-        listOf("Felix", "Sajo", "Jakob", "Mike", "Almin").forEachIndexed { index, name ->
+        players.forEach { p ->
+            val isCurrent = p.id == currentPlayerId
+            val tint = if (isCurrent) Color.Green else Color.White
+
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Icon(
                     imageVector = Icons.Default.Person,
-                    contentDescription = "Player",
-                    tint = if (index == 0) Color.Green else Color.White,
+                    contentDescription = "Player ${p.id}",
+                    tint = tint,
                     modifier = Modifier.size(30.dp)
                 )
-                Text(name, fontSize = 12.sp,
-                    color = if (index == 0) Color.Green else Color.White)
+                Text(text = p.id,
+                    color = tint,
+                    fontSize = 12.sp
+                )
+                Text(
+                    text = "${p.score}P",
+                        color = Color.LightGray,
+                    fontSize = 11.sp
+                )
+
             }
         }
     }

--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
@@ -1183,7 +1183,6 @@ fun BottomScreenBar(viewModel: GameViewModel, gameId: String) {
                             .size(65.dp)
                             .clickable {
                                 viewModel.skipMeeple(gameId)
-                                viewModel.requestScoreUpdate(gameId) // Punkteberechnung starten
                             }
                     )
 

--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
@@ -800,7 +800,7 @@ fun GameplayScreen(gameId: String, playerName: String, stompClient: MyClient, na
 
             Spacer(modifier = Modifier.height(20.dp))
 
-            TileBackRow(viewModel, gameId)
+            TileBackRow(viewModel, gameId, playerName)
 
             Spacer(modifier = Modifier.height(20.dp))
 
@@ -901,26 +901,25 @@ fun PlayerRow() {
 }
 
 @Composable
-fun TileBackRow(viewModel: GameViewModel, gameId: String) {
-    val counters = remember { listOf(mutableIntStateOf(18), mutableIntStateOf(18), mutableIntStateOf(18), mutableIntStateOf(17)) }
+fun TileBackRow(viewModel: GameViewModel, gameId: String, playerId: String) {
+    val deckRemaining by viewModel.deckRemaining.collectAsState(initial = 71)
+
+    val base = deckRemaining / 4
+    val extra = deckRemaining % 4
+    val piles = List(4) { index ->
+        base + if (index < extra) 1 else 0
+    }
 
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceEvenly
     ) {
-        repeat(4) { index ->
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                TileBackButton(
-                    remaining = counters[index].intValue,
-                    onClick = {
-                        if (counters[index].intValue > 0) {
-                            counters[index].intValue -= 1
-                            viewModel.requestTileFromBackend(gameId, "HOST")
-                        }
-                    },
-                    isEnabled = counters[index].intValue > 0
-                )
-            }
+        piles.forEachIndexed { index, remaining ->
+            TileBackButton(
+                remaining = remaining,
+                isEnabled = remaining > 0,
+                onClick = { viewModel.requestTileFromBackend(gameId, playerId) }
+            )
         }
     }
 }

--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
@@ -606,9 +606,7 @@ fun LobbyScreen(gameId: String, playerName: String, stompClient: MyClient, navCo
             "player_joined" -> {
                 val playerArray = json.getJSONArray("players")
                 val host = json.optString("host", "")
-                val currentPlayer = json.optString("currentPlayer", playerName)
                 Log.d("LobbyScreen", "Parsed host=$host vs player=$playerName")
-                viewModel.setJoinedPlayer(currentPlayer)
 
                 Handler(Looper.getMainLooper()).post {
                     players.clear()
@@ -910,6 +908,7 @@ fun TileBackRow(viewModel: GameViewModel, gameId: String, playerId: String) {
     val base = deckRemaining / 4
     val extra = deckRemaining % 4
     val piles = List(4) { index ->
+        base + if (index < extra) 1 else 0
         base + if (index < extra) 1 else 0
     }
 

--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/GameViewModel.kt
@@ -194,6 +194,15 @@ class GameViewModel : ViewModel() {
 
                 "score_update" -> {
                     updateGameWithScore(json)
+
+                    val phaseStr = json.optString("gamePhase", GamePhase.TILE_PLACEMENT.name)
+                    val newPhase = GamePhase.valueOf(phaseStr)
+                    val current = _uiState.value
+                    if (current is GameUiState.Success) {
+                        _uiState.value = GameUiState.Success(
+                            current.gameState.copy(gamePhase = newPhase)
+                        )
+                    }
                     _isMeeplePlacementActive.value = false
                     _currentTile.value = null
                     _validPlacements.value = emptyList()

--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/GameViewModel.kt
@@ -462,6 +462,11 @@ class GameViewModel : ViewModel() {
         Log.d("GameViewModel", "Meeple placement requested: $meepleId by player $playerId")
     }
 
+    fun skipMeeple(gameId: String) {
+        _isMeeplePlacementActive.value = false
+        joinedPlayerName?.let { webSocketClient.sendSkipMeeple(gameId, it) }
+    }
+
     private fun parseMeepleFromJson(json: JSONObject): Meeple {
         return Meeple(
             id = json.getString("id"),

--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/GameViewModel.kt
@@ -33,10 +33,7 @@ fun directionToColor(type: String): Color = when (type) {
 class GameViewModel : ViewModel() {
 
     private var joinedPlayerName: String? = null
-
-    fun setJoinedPlayer(name: String) {
-        joinedPlayerName = name
-    }
+    fun setJoinedPlayer(name: String) { joinedPlayerName = name }
 
     private val _tileDeck = mutableStateListOf<Tile>()
     val tileDeck: List<Tile> = _tileDeck
@@ -117,8 +114,19 @@ class GameViewModel : ViewModel() {
 
             when (type) {
                 "player_joined" -> {
-                    val currentPlayer = json.getString("currentPlayer")
-                    setJoinedPlayer(currentPlayer)
+                    val arr = json.getJSONArray("players")
+                    val newPlayers = (0 until arr.length()).map { i ->
+                        Player(
+                            id = arr.getString(i),
+                            name = arr.getString(i),
+                            score = 0,
+                            availableMeeples = 7,
+                            color = Color.Green
+                        )
+                    }
+                    _players.clear()
+                    _players.addAll(newPlayers)
+                    _currentPlayerId.value = json.getString("currentPlayer")
                 }
 
                 "TILE_DRAWN" -> {
@@ -397,6 +405,10 @@ class GameViewModel : ViewModel() {
         // Sync placed tiles with updated board
         _placedTiles.clear()
         _placedTiles.addAll(updatedBoard.values)
+
+        // Clear drawn tile and valid placements
+        _currentTile.value  = null
+        _validPlacements.value = emptyList()
 
         Log.d("GameViewModel", "Board now has ${updatedBoard.size} placed tiles")
     }

--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/GameViewModel.kt
@@ -9,7 +9,6 @@ import at.se2_ss2025_gruppec.carcasonnefrontend.model.GameState
 import at.se2_ss2025_gruppec.carcasonnefrontend.model.Meeple
 import at.se2_ss2025_gruppec.carcasonnefrontend.model.Player
 import at.se2_ss2025_gruppec.carcasonnefrontend.model.MeeplePosition
-import at.se2_ss2025_gruppec.carcasonnefrontend.model.MeepleType
 import at.se2_ss2025_gruppec.carcasonnefrontend.model.Position
 import at.se2_ss2025_gruppec.carcasonnefrontend.model.Tile
 import at.se2_ss2025_gruppec.carcasonnefrontend.model.TileRotation
@@ -17,11 +16,6 @@ import at.se2_ss2025_gruppec.carcasonnefrontend.websocket.MyClient
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.json.JSONObject
-
-fun getDrawableNameForTile(tile: Tile): String {
-    val baseId = tile.id.substringBefore("-")
-    return baseId.replace("-", "_")
-}
 
 fun Tile.topColor(): Color = directionToColor(this.top)
 fun Tile.rightColor(): Color = directionToColor(this.right)
@@ -64,12 +58,6 @@ class GameViewModel : ViewModel() {
 
     private val _currentPlayerId = mutableStateOf<String?>(null)
     val currentPlayerId: State<String?> = _currentPlayerId
-
-    private val _selectedTile = MutableStateFlow<Tile?>(null)
-    val selectedTile: StateFlow<Tile?> = _selectedTile
-
-    private val _selectedMeeple = MutableStateFlow<Meeple?>(null)
-    val selectedMeeple: StateFlow<Meeple?> = _selectedMeeple
 
     private val _isMeeplePlacementActive = MutableStateFlow(false)
     val isMeeplePlacementActive: StateFlow<Boolean> get() = _isMeeplePlacementActive
@@ -405,10 +393,6 @@ class GameViewModel : ViewModel() {
         // Sync placed tiles with updated board
         _placedTiles.clear()
         _placedTiles.addAll(updatedBoard.values)
-
-        // Clear selections
-        _selectedTile.value = null
-        // _currentTile.value = null
 
         Log.d("GameViewModel", "Board now has ${updatedBoard.size} placed tiles")
     }

--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/GameViewModel.kt
@@ -50,6 +50,9 @@ class GameViewModel : ViewModel() {
     private val _validPlacements = MutableStateFlow<List<Pair<Position,TileRotation>>>(emptyList())
     val validPlacements: StateFlow<List<Pair<Position,TileRotation>>> = _validPlacements
 
+    private val _deckRemaining = MutableStateFlow(0)
+    val deckRemaining: StateFlow<Int> = _deckRemaining
+
     private val _uiState = MutableStateFlow<GameUiState>(GameUiState.Loading)
     val uiState: StateFlow<GameUiState> = _uiState
 
@@ -135,6 +138,10 @@ class GameViewModel : ViewModel() {
                         }
                         _validPlacements.value = validPlacementList
                     }
+                }
+
+                "deck_update" -> {
+                    _deckRemaining.value = json.getInt("deckRemaining")
                 }
 
                 "board_update" -> {
@@ -228,15 +235,8 @@ class GameViewModel : ViewModel() {
                         // Meeple-Modus aktivieren, wenn wir uns in der Phase MEEPLE_PLACEMENT befinden
                         setMeeplePlacement(newPhase == GamePhase.MEEPLE_PLACEMENT)
 
-                        // Falls gewünschte Reaktion beim Scoring nötig:
-                        /*if (newPhase == GamePhase.SCORING) {
-                            // z. B. gleich Punkteberechnung anstoßen oder UI-Hinweis zeigen
-                            requestScoreUpdateIfNeeded()
-                        }*/ //TODO: MIKE@Felix, brauchst du sowas?
-
                         // Log.d("WebSocket", "Meeple gesetzt: ${meeple.id} an Position ($position.x, $position.y)")
                         Log.d("GameViewModel", "Meeple gesetzt: ${meeple.id}, verbleibende Meeples für $playerId: $remainingMeeple")
-
 
                     } catch (e: Exception) {
                         Log.e("WebSocket", "Fehler beim Verarbeiten von meeple_placed: ${e.message}")

--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/websocket/MyClient.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/websocket/MyClient.kt
@@ -175,6 +175,17 @@ class MyClient(val callbacks: Callbacks) {
         }
     }
 
+    fun sendPlaceTileRequest(payload: String){
+        scope.launch {
+            try {
+                session?.sendText("/app/game/send", payload)
+                Log.d("WebSocket", "Tile placement request sent: $payload")
+            } catch (e: Exception) {
+                Log.e("WebSocket", "Failed to send tile placement request: ${e.message}")
+
+            }
+        }
+    }
 
     fun sendPlaceMeeple(gameId: String, playerId: String, meepleId: String, tileId: String, position: String) {
         val json = JSONObject().apply {
@@ -184,7 +195,6 @@ class MyClient(val callbacks: Callbacks) {
             put("meeple", JSONObject().apply {
                 put("id", meepleId)
                 put("playerId", playerId)
-                // put("type", "MONK") // TODO MIKE: Sollte entfallen und rein im Backend gelöst werden.
                 put("tileId", tileId)
                 put("position", position)
             })
@@ -199,15 +209,16 @@ class MyClient(val callbacks: Callbacks) {
             }
         }
     }
-    fun sendPlaceTileRequest(payload: String){
-        scope.launch {
-            try {
-                session?.sendText("/app/game/send", payload)
-                Log.d("WebSocket", "Tile placement request sent: $payload")
-            } catch (e: Exception) {
-                Log.e("WebSocket", "Failed to send tile placement request: ${e.message}")
 
-            }
+    fun sendSkipMeeple(gameId: String, playerId: String) {
+        val json = JSONObject().apply {
+            put("type",     "skip_meeple")
+            put("gameId",   gameId)
+            put("player",   playerId)
+        }
+        scope.launch {
+            session?.sendText("/app/game/send", json.toString())
+            Log.d("WebSocket", "Skip meeple sent: $json")
         }
     }
 

--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/websocket/MyClient.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/websocket/MyClient.kt
@@ -22,13 +22,7 @@ import at.se2_ss2025_gruppec.carcasonnefrontend.model.dto.MeepleDto
 class MyClient(val callbacks: Callbacks) {
 
     private val WEBSOCKET_URI = "ws://10.0.2.2:8080/ws/game" // Enter your local IP address instead of localhost (10.0.2.2) for real device demo!
-    //private val WEBSOCKET_URI = "ws://192.168.8.54:8080/ws/game"
-
-    private lateinit var topicFlow: Flow<String>
-    private lateinit var collector: Job
-
-    private lateinit var jsonFlow: Flow<String>
-    private lateinit var jsonCollector: Job
+    //private val WEBSOCKET_URI = "ws://192.168.0.255:8080/ws/game"
 
     private lateinit var client: StompClient
     private var session: StompSession? = null
@@ -71,34 +65,6 @@ class MyClient(val callbacks: Callbacks) {
             } catch (e: Exception) {
                 Log.e("WebSocket", "WebSocket connection failed: ${e.message}")
                 callback("Login failed: ${e.message}")
-            }
-        }
-    }
-
-    fun sendHello() {
-        scope.launch {
-            try {
-                session?.sendText("/app/hello", "message from client")
-                Log.d("WebSocket", "Message sent: Hello")
-            } catch (e: Exception) {
-                Log.e("WebSocket", "Failed to send hello: ${e.message}")
-            }
-        }
-    }
-
-    fun sendJson() {
-        val json = JSONObject().apply {
-            put("from", "client")
-            put("text", "from client")
-        }
-        val message = json.toString()
-
-        scope.launch {
-            try {
-                session?.sendText("/app/object", message)
-                Log.d("WebSocket", "JSON message sent: $message")
-            } catch (e: Exception) {
-                Log.e("WebSocket", "Failed to send JSON: ${e.message}")
             }
         }
     }
@@ -219,22 +185,6 @@ class MyClient(val callbacks: Callbacks) {
         scope.launch {
             session?.sendText("/app/game/send", json.toString())
             Log.d("WebSocket", "Skip meeple sent: $json")
-        }
-    }
-
-    fun sendCalculateScoreRequest(gameId: String) {
-        val json = JSONObject().apply {
-            put("type", "calculate_score")
-            put("gameId", gameId)
-        }
-
-        scope.launch {
-            try {
-                session?.sendText("/app/game/send", json.toString())
-                Log.d("WebSocket", "Calculate score request sent: $json")
-            } catch (e: Exception) {
-                Log.e("WebSocket", "Failed to send calculate score request: ${e.message}")
-            }
         }
     }
 }


### PR DESCRIPTION
- Phase synchronization & turn fix: Updated the score_update handler to read the server‑sent gamePhase, update GameState.gamePhase, and correctly advance to the next player.

- Deck counter integration: Wired up the deck_update message to refresh the tile‑back counters in the bottom bar, ensuring all clients display the same remaining‑tiles split.

- Score display & tile bug fix: Enhanced updateGameWithScore to update player scores in the PlayerRow, and resolved an issue where the drawn tile wasn’t cleared or shown properly after placement.

- Skip‑meeple support: Added UI logic to send the skip_meeple message when the “no‑meeple” button is tapped, and correctly toggle meeple‑placement mode.