### PR TITLE
feat: switch to gameplay music on entering gameplay screen and improv…

### DIFF
--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/MainActivity.kt
@@ -83,6 +83,7 @@ import androidx.core.graphics.createBitmap
 import at.se2_ss2025_gruppec.carcasonnefrontend.model.GamePhase
 import at.se2_ss2025_gruppec.carcasonnefrontend.model.Player
 import java.util.UUID
+import androidx.compose.foundation.BorderStroke
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -583,7 +584,6 @@ fun CreateGameScreen(navController: NavController) {
 @SuppressLint("UnrememberedGetBackStackEntry")
 @Composable
 fun LobbyScreen(gameId: String, playerName: String, stompClient: MyClient, navController: NavController) {
-
     val backStackEntry = remember(navController, gameId) {
         navController.getBackStackEntry("lobby/$gameId")
     }
@@ -595,7 +595,6 @@ fun LobbyScreen(gameId: String, playerName: String, stompClient: MyClient, navCo
     val context = LocalContext.current
 
     fun handleLobbyMessage(message: String) {
-        Log.d("WebSocket", "Received message: $message")
         val json = JSONObject(message)
         when (json.getString("type")) {
             "game_started" -> {
@@ -606,8 +605,6 @@ fun LobbyScreen(gameId: String, playerName: String, stompClient: MyClient, navCo
             "player_joined" -> {
                 val playerArray = json.getJSONArray("players")
                 val host = json.optString("host", "")
-                Log.d("LobbyScreen", "Parsed host=$host vs player=$playerName")
-
                 Handler(Looper.getMainLooper()).post {
                     players.clear()
                     for (i in 0 until playerArray.length()) {
@@ -620,140 +617,115 @@ fun LobbyScreen(gameId: String, playerName: String, stompClient: MyClient, navCo
     }
 
     LaunchedEffect(Unit) {
-        while (!stompClient.isConnected()) {
-            delay(100)
-        }
-        //Subscribe to both public and private channels
+        while (!stompClient.isConnected()) delay(100)
+
         stompClient.listenOn("/topic/game/$gameId") { handleLobbyMessage(it) }
         stompClient.listenOn("/user/queue/private") { handleLobbyMessage(it) }
-        delay(700) //In order to give time for subscription to happen
-        //Send join AFTER subscriptions
+        delay(700)
         try {
-            Log.d("LobbyScreen", "Sending join_game for $playerName to $gameId")
             stompClient.sendJoinGame(gameId, playerName)
-
         } catch (e: Exception) {
-            Log.e("LobbyScreen", "Failed to send join_game: ${e.message}")
-            Toast.makeText(context, "Failed to join game: ${e.message}", Toast.LENGTH_LONG).show()
+            Toast.makeText(context, "Join failed: ${e.message}", Toast.LENGTH_LONG).show()
         }
     }
 
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         BackgroundImage()
 
-        Text(
-            text = "Lobby",
-            fontSize = 36.sp,
-            fontWeight = FontWeight.Bold,
-            fontFamily = FontFamily.Serif,
-            letterSpacing = 2.sp,
-            color = Color(0xFFFFF4C2),
+        PixelArtTitle(
+            title = "Game Lobby",
+            backgroundRes = R.drawable.bg_pxart,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 65.dp)
-                .padding(start = 150.dp)
+                .padding(top = 54.dp)
                 .align(Alignment.TopCenter)
         )
 
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = 80.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+                .padding(top = 228.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(
-                    modifier = Modifier
-                        .border(2.dp, Color(0xFFFFF4C2), RoundedCornerShape(12.dp))
-                        .padding(12.dp)
-                        .background(Color(0x99000000))
+            // Game ID block
+            Card(
+                shape = RoundedCornerShape(16.dp),
+                border = BorderStroke(2.dp, Color(0xFFFFF4C2)),
+                colors = CardDefaults.cardColors(containerColor = Color(0x66000000)),
+                modifier = Modifier
+                    .padding(bottom = 24.dp)
+                    .fillMaxWidth(0.6f)
+                    .height(70.dp)
+            ) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
                         text = "Game ID: $gameId",
-                        fontSize = 22.sp,
+                        fontSize = 20.sp,
                         fontWeight = FontWeight.Bold,
                         color = Color(0xFFFFF4C2)
                     )
-                }
-
-                Spacer(modifier = Modifier.width(8.dp))
-
-                IconButton(onClick = {
-                    clipboardManager.setText(AnnotatedString(gameId))
-                    Toast.makeText(context, "Copied Game ID", Toast.LENGTH_SHORT).show()
-                }) {
-                    Icon(
-                        imageVector = Icons.Default.ContentCopy,
-                        contentDescription = "Copy Game ID",
-                        tint = Color.White
-                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    IconButton(onClick = {
+                        clipboardManager.setText(AnnotatedString(gameId))
+                        Toast.makeText(context, "Copied Game ID", Toast.LENGTH_SHORT).show()
+                    }) {
+                        Icon(
+                            imageVector = Icons.Default.ContentCopy,
+                            contentDescription = "Copy Game ID",
+                            tint = Color.White
+                        )
+                    }
                 }
             }
-
-            Spacer(modifier = Modifier.height(24.dp))
 
             Text(
-                text = "Waiting for players...",
-                fontSize = 19.sp,
-                fontWeight = FontWeight.Bold,
+                text = "Waiting for players to join...",
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Medium,
                 color = Color.White
             )
-            Spacer(modifier = Modifier.height(24.dp))
+
+            Spacer(modifier = Modifier.height(20.dp))
 
             val maxPlayers = 4
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                for (i in 0 until maxPlayers) {
+                    val playerNameInList = players.getOrNull(i) ?: "Empty Slot"
+                    val displayName = if (playerNameInList.trim() == playerName.trim()) "You" else playerNameInList
 
-            for (i in 0 until maxPlayers) {
-                val playerNameInList = players.getOrNull(i) ?: "Empty Slot"
-                val displayName =
-                    if (playerNameInList.trim() == playerName.trim()) "You" else playerNameInList
-
-                Button(
-                    onClick = { },
-                    enabled = false,
-                    modifier = Modifier
-                        .fillMaxWidth(0.7f)
-                        .height(48.dp)
-                        .padding(vertical = 6.dp),
-                    shape = RoundedCornerShape(12.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = Color(0x995A3A1A),
-                        disabledContainerColor = Color(0x995A3A1A),
-                        disabledContentColor = Color.White
-                    )
-                ) {
-                    Text(
-                        text = displayName,
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Medium
-                    )
+                    Card(
+                        shape = RoundedCornerShape(12.dp),
+                        border = BorderStroke(1.dp, Color(0xFFFFF4C2)),
+                        colors = CardDefaults.cardColors(containerColor = Color(0x995A3A1A)),
+                        modifier = Modifier
+                            .fillMaxWidth(0.6f)
+                            .height(50.dp)
+                    ) {
+                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            Text(
+                                text = displayName,
+                                fontSize = 16.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                color = Color.White
+                            )
+                        }
+                    }
                 }
             }
 
-            Spacer(modifier = Modifier.height(68.dp))
+            Spacer(modifier = Modifier.height(56.dp))
 
             if (hostName.value == playerName) {
-                Button(
+                PixelArtButton(
+                    label = "Start Game",
                     onClick = {
                         Toast.makeText(context, "Game starting...", Toast.LENGTH_SHORT).show()
-                        stompClient.sendStartGame(gameId,playerName)
-                    },
-                    modifier = Modifier
-                        .width(200.dp)
-                        .height(52.dp),
-                    shape = RoundedCornerShape(14.dp),
-                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xCC5A3A1A))
-                ) {
-                    Text(
-                        text = "Start Game",
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = Color.White
-                    )
-                }
+                        stompClient.sendStartGame(gameId, playerName)
+                    }
+                )
             }
         }
     }
@@ -762,6 +734,7 @@ fun LobbyScreen(gameId: String, playerName: String, stompClient: MyClient, navCo
 @SuppressLint("UnrememberedGetBackStackEntry")
 @Composable
 fun GameplayScreen(gameId: String, playerName: String, stompClient: MyClient, navController: NavController) {
+    val context = LocalContext.current
 
     val backStackEntry = remember(navController, gameId) {
         navController.getBackStackEntry("lobby/$gameId")
@@ -776,10 +749,13 @@ fun GameplayScreen(gameId: String, playerName: String, stompClient: MyClient, na
         viewModel.joinGame(gameId, playerName)
     }
 
+    // 🔊 Music switch (only once on enter)
+    LaunchedEffect(Unit) {
+        SoundManager.playMusic(context, R.raw.gameplay_music)
+    }
+
     val uiState by viewModel.uiState.collectAsState()
 
-    // Phase-Flags (TILE-, MEEPLE- oder SCORING-Phase)
-    // uiState kann Loading / Error / Success sein → deshalb erst casten
     val phase = (uiState as? GameUiState.Success)
         ?.gameState
         ?.gamePhase
@@ -824,25 +800,14 @@ fun GameplayScreen(gameId: String, playerName: String, stompClient: MyClient, na
                         }
                     },
 
-                    // Meeple platzieren
                     onMeepleClick = { x, y, zone ->
-                        if (!meepleMode) return@PannableTileGrid // wir sind nicht im Meeple-Modus
-                        Log.d("GameplayScreen", "MeepleClick ausgelöst: x=$x, y=$y, zone=$zone") // Debug-Log für zone!
+                        if (!meepleMode) return@PannableTileGrid
 
-                        // Tile unter (x,y) im Board suchen
                         val clickedPos  = Position(x, y)
-                        val targetTile = gameState.board[clickedPos] ?: run {
-                            Log.e("GameplayScreen", "No tile at $clickedPos → kein Meeple möglich")
-                            return@PannableTileGrid
-                        }
+                        val targetTile = gameState.board[clickedPos] ?: return@PannableTileGrid
 
-                        // Einmalige Meeple-ID erzeugen
                         val meepleId = UUID.randomUUID().toString()
                         val playerId = TokenManager.loggedInUsername ?: "unknown"
-
-                        Log.d("GameplayScreen",
-                            "Meeple wird platziert → game=$gameId, player=$playerId, " +
-                                    "tile=${targetTile.id}, zone=${zone.name}")
 
                         viewModel.placeMeeple(
                             gameId  = gameId,
@@ -859,7 +824,6 @@ fun GameplayScreen(gameId: String, playerName: String, stompClient: MyClient, na
             Spacer(modifier = Modifier.height(20.dp))
 
             BottomScreenBar(viewModel, gameId)
-
         }
     }
 }
@@ -1303,5 +1267,33 @@ fun DrawTile(tile: Tile, viewModel: GameViewModel) {
         ) {
             Text(text = "?", color = Color.White)
         }
+    }
+}
+@Composable
+fun PixelArtTitle(
+    title: String,
+    backgroundRes: Int = R.drawable.bg_pxart,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .width(260.dp)
+            .height(80.dp)
+    ) {
+        Image(
+            painter = painterResource(id = backgroundRes),
+            contentDescription = "Lobby Title Background",
+            contentScale = ContentScale.FillBounds,
+            modifier = Modifier.matchParentSize()
+        )
+        Text(
+            text = title,
+            fontSize = 26.sp,
+            fontWeight = FontWeight.ExtraBold,
+            letterSpacing = 2.sp,
+            color = Color(0xFFFFF4C2),
+            fontFamily = FontFamily.Serif,
+            modifier = Modifier.align(Alignment.Center)
+        )
     }
 }


### PR DESCRIPTION
Implemented the transition to gameplay music upon entering the gameplay screen, replacing the previously continuous lobby track. Additionally, it updates the LobbyScreen UI with a pixel art title component, a styled Game ID display card, and improved visual presentation of player slots. These changes enhance both user experience and visual consistency.