### PR TITLE
feat: Dynamic player Meeple colors across UI

### DIFF
--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/viewmodel/GameViewModel.kt
@@ -21,26 +21,10 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 
-fun Tile.topColor(): Color = directionToColor(this.top)
-fun Tile.rightColor(): Color = directionToColor(this.right)
-fun Tile.bottomColor(): Color = directionToColor(this.bottom)
-fun Tile.leftColor(): Color = directionToColor(this.left)
-
-fun directionToColor(type: String): Color = when (type) {
-    "ROAD" -> Color.Yellow
-    "CITY" -> Color.Red
-    "MONASTERY" -> Color.Blue
-    "FIELD" -> Color.Green
-    else -> Color.Gray
-}
-
 class GameViewModel : ViewModel() {
 
     private var joinedPlayerName: String? = null
     fun setJoinedPlayer(name: String) { joinedPlayerName = name }
-
-    private val _tileDeck = mutableStateListOf<Tile>()
-    val tileDeck: List<Tile> = _tileDeck
 
     private val _placedTiles = mutableStateListOf<Tile>()
     val placedTiles: List<Tile> = _placedTiles
@@ -310,75 +294,6 @@ class GameViewModel : ViewModel() {
             hasShield = json.optBoolean("hasShield", false),
             tileRotation = TileRotation.valueOf(json.optString("tileRotation", "NORTH"))
         )
-    }
-
-    fun tileCountFor(id: String): Int = when (id) {
-        "tile-a" -> 2
-        "tile-b" -> 4
-        "tile-c" -> 1
-        "tile-d" -> 4
-        "tile-e" -> 5
-        "tile-f" -> 2
-        "tile-g" -> 1
-        "tile-h" -> 3
-        "tile-i" -> 2
-        "tile-j" -> 3
-        "tile-k" -> 3
-        "tile-m" -> 3
-        "tile-n" -> 3
-        "tile-o" -> 2
-        "tile-p" -> 2
-        "tile-q" -> 3
-        "tile-r" -> 1
-        "tile-s" -> 3
-        "tile-t" -> 2
-        "tile-u" -> 1
-        "tile-v" -> 8
-        "tile-w" -> 9
-        "tile-x" -> 4
-        "tile-y" -> 1
-        else -> 1
-    }
-
-    fun createShuffledDeck() {
-        val baseTiles = listOf(
-            Tile("tile-a", "FIELD", "FIELD", "ROAD", "FIELD", hasMonastery = true),
-            Tile("tile-b", "FIELD", "FIELD", "FIELD", "FIELD", hasMonastery = true),
-            Tile("tile-c", "CITY", "CITY", "CITY", "CITY", hasShield = true),
-            Tile("tile-d", "CITY", "ROAD", "FIELD", "ROAD"),
-            Tile("tile-e", "CITY", "FIELD", "FIELD", "FIELD", hasShield = true),
-            Tile("tile-f", "FIELD", "CITY", "FIELD", "CITY", hasShield = true),
-            Tile("tile-g", "FIELD", "CITY", "FIELD", "CITY"),
-            Tile("tile-h", "CITY", "FIELD", "CITY", "FIELD"),
-            Tile("tile-i", "CITY", "FIELD", "FIELD", "CITY"),
-            Tile("tile-j", "CITY", "ROAD", "ROAD", "FIELD"),
-            Tile("tile-k", "CITY", "FIELD", "ROAD", "ROAD"),
-            Tile("tile-m", "CITY", "ROAD", "ROAD", "ROAD"),
-            Tile("tile-n", "CITY", "CITY", "FIELD", "FIELD"),
-            Tile("tile-o", "CITY", "CITY", "FIELD", "FIELD", hasShield = true),
-            Tile("tile-p", "CITY", "ROAD", "ROAD", "CITY", hasShield = true),
-            Tile("tile-q", "CITY", "ROAD", "ROAD", "CITY"),
-            Tile("tile-r", "CITY", "CITY", "FIELD", "CITY", hasShield = true),
-            Tile("tile-s", "CITY", "CITY", "FIELD", "CITY"),
-            Tile("tile-t", "CITY", "CITY", "ROAD", "CITY", hasShield = true),
-            Tile("tile-u", "CITY", "CITY", "ROAD", "CITY"),
-            Tile("tile-v", "ROAD", "FIELD", "ROAD", "FIELD"),
-            Tile("tile-w", "FIELD", "FIELD", "ROAD", "ROAD"),
-            Tile("tile-x", "FIELD", "ROAD", "ROAD", "ROAD"),
-            Tile("tile-y", "ROAD", "ROAD", "ROAD", "ROAD")
-        )
-
-        val fullDeck = baseTiles.flatMap { tile ->
-            List(tileCountFor(tile.id)) { index -> tile.copy(id = "${tile.id}-$index") }
-        }
-
-        _tileDeck.clear()
-        _tileDeck.addAll(fullDeck.shuffled())
-    }
-
-    fun drawNextTile() {
-        _currentTile.value = if (_tileDeck.isNotEmpty()) _tileDeck.removeAt(0) else null
-        println("Drawn tile: ${_currentTile.value}")
     }
 
     fun Tile.rotateClockwise(): Tile {

--- a/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/websocket/MyClient.kt
+++ b/app/src/main/java/at/se2_ss2025_gruppec/carcasonnefrontend/websocket/MyClient.kt
@@ -4,8 +4,6 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import at.se2_ss2025_gruppec.carcasonnefrontend.TokenManager
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.hildan.krossbow.stomp.StompClient
@@ -16,8 +14,6 @@ import org.hildan.krossbow.stomp.sendText
 import org.hildan.krossbow.stomp.subscribeText
 import org.hildan.krossbow.websocket.okhttp.OkHttpWebSocketClient
 import org.json.JSONObject
-import at.se2_ss2025_gruppec.carcasonnefrontend.model.dto.MeepleDto
-
 
 class MyClient(val callbacks: Callbacks) {
 
@@ -85,6 +81,7 @@ class MyClient(val callbacks: Callbacks) {
             }
         }
     }
+
     fun listenOn(topic: String, onMessage: (String) -> Unit) {
         scope.launch {
             try {
@@ -102,7 +99,6 @@ class MyClient(val callbacks: Callbacks) {
         }
     }
 
-
     fun isConnected(): Boolean {
         return session != null
     }
@@ -113,8 +109,6 @@ class MyClient(val callbacks: Callbacks) {
             put("player", playerName)
         }
 
-
-
         scope.launch {
             try {
                 session?.sendText("/app/game/send", json.toString())
@@ -124,6 +118,7 @@ class MyClient(val callbacks: Callbacks) {
             }
         }
     }
+
     fun sendDrawTileRequest(gameId: String, playerId: String) {
         val json = JSONObject().apply {
             put("type", "DRAW_TILE")


### PR DESCRIPTION
Description:
This PR enhances the frontend so that each player’s Meeple and related UI elements now consistently reflect their assigned color, rather than defaulting to blue. It wires up the viewModel.players list (with per-player Color values) throughout the game screen and bottom bar, and replaces all hard-coded icons/tints accordingly.

Changes:
- PlayerRow: Render each participant’s avatar as a Meeple icon tinted to their color, and highlight the current player.
- PannableTileGrid: Choose the correct colored Meeple drawable based on the player index when drawing placed Meeples.
- BottomScreenBar: Remaining-Meeple counter and “no-Meeple” button both adapt to the player’s color.
- Switched all code to use viewModel.players (with their color properties) rather than the static gameState.players, ensuring centralized color assignment.

_Additional changes:_
- subscribe to game WS channels just once (to avoid duplicate toasts)
- display error toasts only to players who caused them
- receive initial board and deck state before gameplay starts
- remove meeples from the board upon scoring
- accurate scores and meeple counts in the bottom bar
- only activate skip-meeple button during meeple placement (can otherwise be used to skip drawn tile)
- Refactoring: removed outdated functions/variables/imports

Related Issues:
Closes #19
Closes #71 